### PR TITLE
feat: real cache check for AllDebrid via bulk upload/delete

### DIFF
--- a/stream_fusion/utils/debrid/alldebrid.py
+++ b/stream_fusion/utils/debrid/alldebrid.py
@@ -311,9 +311,12 @@ class AllDebrid(BaseDebrid):
                 for h in batch:
                     results[h] = {"hash": h, "instant": False, "files": []}
 
-        cached_count = sum(1 for v in results.values() if v.get("instant"))
-        logger.info(f"AllDebrid: Cache check complete — {cached_count}/{len(hashes)} cached")
-        return {"status": "success", "data": {"magnets": list(results.values())}}
+        # Only return cached items — _update_availability_alldebrid marks every item in the
+        # response as "AD" available without checking the `instant` field, so non-cached
+        # hashes must be excluded (they stay with availability=False in TorrentSmartContainer)
+        cached_magnets = [v for v in results.values() if v.get("instant")]
+        logger.info(f"AllDebrid: Cache check complete — {len(cached_magnets)}/{len(hashes)} cached")
+        return {"status": "success", "data": {"magnets": cached_magnets}}
 
     async def add_magnet_or_torrent(self, magnet, torrent_download=None, torrent_file_content=None, ip=None):
         logger.debug(f"AllDebrid: Adding magnet or torrent")

--- a/stream_fusion/utils/debrid/realdebrid.py
+++ b/stream_fusion/utils/debrid/realdebrid.py
@@ -176,11 +176,15 @@ class RealDebrid(BaseDebrid):
                 logger.warning(f"Real-Debrid: StremThru cache check failed ({e}), falling back to stub")
 
         # --- Stub fallback: mark everything as available ---
+        # Return StremThru list format so TorrentSmartContainer routes through
+        # _update_availability_stremthru (which handles this shape correctly).
+        # _update_availability_realdebrid expects the old {hash: {"rd": [...]}} format
+        # and would silently skip our dict — using the list format avoids that mismatch.
         logger.warning("Real-Debrid: StremThru not configured or failed — marking all hashes as available (stub)")
-        return {
-            "status": "success",
-            "data": {"magnets": [{"hash": h, "instant": True, "files": []} for h in (hashes or hashes_or_magnets)]},
-        }
+        return [
+            {"hash": h, "status": "cached", "files": [], "store_name": "realdebrid", "debrid": "RD"}
+            for h in (hashes or hashes_or_magnets)
+        ]
 
     async def get_stream_link(self, query, config=None, ip=None):
         # Extract query parameters


### PR DESCRIPTION
## Résumé

- **AllDebrid** : remplace le stub `instant:True` par une vraie vérification de cache hybride
- **RealDebrid** : remplace le retour vide par un fallback stub propre avec warning

## Détails AllDebrid

Nouvelle stratégie en deux étapes dans `get_availability_bulk()` :

1. **StremThru** (si configuré) — check via le réseau communautaire, marque les hashes trouvés comme cachés
2. **Bulk upload/delete** pour les hashes restants :
   - Magnets stripped (`magnet:?xt=urn:btih:{hash}` sans trackers) → AllDebrid vérifie son cache sans démarrer de téléchargement
   - Batches de 20 (sous la limite de 30 slots actifs)
   - Champ `ready` lu directement dans la réponse du upload (pas d'appel `/status` supplémentaire)
   - Delete en `asyncio.gather()` par batch
   - Gestion `MAGNET_TOO_MANY_ACTIVE` propre

Rate limiter AllDebrid augmenté de 250/60 → 600/60 (10 req/s, limite officielle : 12 req/s).

## Détails RealDebrid

- StremThru si configuré → résultats du réseau communautaire
- Stub `instant:True` + warning si StremThru absent ou en erreur
- Suppression de l'appel `_torrent_rate_limit()` inutile en entrée de fonction

## Test plan

- [ ] AllDebrid + StremThru : vérifier logs `"StremThru found X cached, Y remaining for bulk check"` + aucun magnet résiduel sur le compte AD
- [ ] AllDebrid sans StremThru : vérifier logs `"bulk-checking all hashes"` + zéro magnet résiduel
- [ ] AllDebrid avec 30 slots occupés : vérifier `"Too many active magnets"` sans crash
- [ ] RealDebrid + StremThru : vérifier résultats cohérents avec la réalité
- [ ] RealDebrid sans StremThru : vérifier warning + stub actif

🤖 Generated with [Claude Code](https://claude.com/claude-code)