### PR TITLE
fix: AD bulk cache check — raw hashes, finally cleanup, local redis redis cache

### DIFF
--- a/stream_fusion/utils/debrid/alldebrid.py
+++ b/stream_fusion/utils/debrid/alldebrid.py
@@ -334,11 +334,10 @@ class AllDebrid(BaseDebrid):
                     if m.get("id"):
                         ids_to_delete.append(m["id"])
                     if "error" in m:
-                        # MAGNET_INVALID_URI on a valid hash likely means AD doesn't know it
-                        # (no trackers → can't verify unknown hashes). Do NOT cache this result
-                        # as it's an API limitation, not a confirmed "not in cache" state.
+                        # MAGNET_INVALID_URI on a valid 40-char hash = AD doesn't have it in
+                        # cache. Treat as a confirmed "not cached" response and store in Redis.
                         results[mh] = {"hash": mh, "instant": False, "files": []}
-                        # intentionally NOT added to api_confirmed → not stored in Redis
+                        api_confirmed[mh] = False
                     else:
                         # The upload response only contains `ready: bool` — no statusCode field
                         is_ready = bool(m.get("ready", False))


### PR DESCRIPTION
## Contexte

Suite au merge de la PR #73 (bulk cache check AllDebrid), cette PR apporte plusieurs améliorations de robustesse et ajoute un cache Redis partagé entre utilisateurs pour éviter de re-interroger l'API AllDebrid inutilement.

---

## Changements

### 1. Hash brut au lieu de magnet URI strippé

L'API AllDebrid accepte nativement les hashes bruts (`"abc123def..."`) sans avoir besoin de les encapsuler dans un URI magnet. C'est plus court, sans ambiguïté, et produit le même résultat.

```python
# Avant
data={"magnets[]": [f"magnet:?xt=urn:btih:{h}" for h in batch]}

# Après
data={"magnets[]": batch}  # hashes bruts directement
```

---

### 2. `finally` pour garantir la suppression des magnets temporaires

Les magnets uploadés pour le check étaient supprimés dans le bloc `try`. Si une exception survenait entre l'upload et le delete, les magnets restaient sur le compte AllDebrid de l'utilisateur.

Le `finally` garantit la suppression dans tous les cas, y compris en cas d'exception.

---

### 3. Gestion correcte des réponses erreur de l'API AD

Les réponses erreur (ex. `MAGNET_INVALID_URI`) ne contiennent pas de champ `"hash"` — seulement `"magnet"` (la valeur originale envoyée). Notre code tombait silencieusement dans un `continue` car `m.get("hash")` retournait `None`.

Fix : fallback sur `m.get("magnet")` pour récupérer le hash depuis les réponses erreur.

```python
mh = (m.get("hash") or m.get("magnet") or "").lower()
```

---

### 4. `MAGNET_INVALID_URI` = hash non caché chez AD

`MAGNET_INVALID_URI` retourné sur un hash valide (40 chars hex) signifie qu'AllDebrid ne connaît pas ce hash dans son cache — c'est une réponse confirmée "non caché", pas une erreur de format. Traité et mis en cache Redis en conséquence.

---

### 5. Suppression de la vérification `statusCode == 4`

Le champ `statusCode` n'est présent que dans la réponse de `/v4.1/magnet/status`, **pas** dans `/v4/magnet/upload`. La vérification ne se déclenchait donc jamais. Seul `ready: bool` est utilisé.

---

### 6. Cache Redis partagé entre utilisateurs

**Le changement principal de cette PR.**

Avant cette PR, chaque utilisateur re-vérifiait les mêmes hashes via l'API AllDebrid à chaque recherche. Avec ce cache, les résultats de disponibilité sont partagés entre tous les utilisateurs de l'instance.

#### Clés Redis
```
debrid:availability:ad:{hash}  →  True | False
```

#### TTL
| Résultat | TTL | Raison |
|---|---|---|
| `ready: true` (en cache AD) | **7 jours** | Un torrent en cache reste disponible longtemps |
| `ready: false` / `MAGNET_INVALID_URI` (non caché) | **1 heure** | Peut devenir disponible rapidement |
| Erreur globale / exception | **jamais mis en cache** | Mauvais token ou réseau → ne pas polluer |

#### Lookup optimisé
Un seul appel Redis `mget` pour tous les hashes simultanément. Seuls les hashes absents du cache passent à l'étape suivante (StremThru puis bulk AD).

#### Règles anti-pollution
Un utilisateur avec un token invalide ou une mauvaise configuration **ne peut pas polluer le cache partagé** :

| Situation | Mis en Redis ? |
|---|---|
| `ready: true` — API success | ✅ 7 jours |
| `ready: false` — API success, hash présent dans réponse | ✅ 1h |
| `MAGNET_INVALID_URI` — hash valide, AD ne le connaît pas | ✅ 1h |
| `MAGNET_TOO_MANY_ACTIVE` — erreur globale batch | ❌ jamais |
| Token invalide / erreur auth | ❌ jamais |
| Exception réseau / timeout | ❌ jamais |
| Hash absent de la réponse (cas inconnu) | ❌ jamais |

#### StremThru non mis en cache
Les résultats de StremThru **ne sont pas stockés dans Redis**. StremThru gère son propre cache communautaire et le maintient à jour en temps réel — le mettre en cache localement servirait des données potentiellement obsolètes.

---

## Flow complet après cette PR

```
Requête utilisateur
    ↓
Redis mget (tous les hashes en un seul appel)
    ├── hit → résultat immédiat, pas d'appel AD
    └── miss → hashes inconnus seulement
                    ↓
              StremThru (si configuré) — appelé frais, jamais mis en cache Redis
                    ↓ hashes non trouvés par StremThru
              Bulk upload AD (batches de 20, hashes bruts)
                    ├── ready:true  → instant:True  + Redis 7j
                    ├── ready:false → instant:False + Redis 1h
                    ├── MAGNET_INVALID_URI → instant:False + Redis 1h
                    └── erreur/exception → instant:False, Redis rien
              Delete magnets temporaires (finally, toujours exécuté)
```

---

## Test plan

- [ ] Vérifier que les hashes bruts sont acceptés par l'API AD (`status: success`)
- [ ] Première recherche : logs `"Stored X results in Redis"` + `"Deleted X temporary magnets"`
- [ ] Deuxième recherche sur le même contenu : logs `"Redis cache hit for X/Y hashes"` — aucun appel bulk AD
- [ ] Vérifier que le compte AD ne garde aucun magnet résiduel après une exception simulée
- [ ] Tester avec un token invalide : vérifier qu'aucune entrée Redis n'est créée

🤖 Generated with [Claude Code](https://claude.com/claude-code)